### PR TITLE
Fix usage keys from Object.prototype (like "hasOwnProperty")

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,5 +14,6 @@
   "quotmark": "single",
   "freeze": true,
   "nonbsp": true,
-  "node": true
+  "node": true,
+  "strict": true
 }

--- a/lib/memory-cache.js
+++ b/lib/memory-cache.js
@@ -7,8 +7,8 @@
  * @constructor
  */
 function MemoryCache() {
-    this._cache = {};
-    this._expires = {};
+    this._cache = createMap();
+    this._expires = createMap();
 }
 
 /**
@@ -44,7 +44,7 @@ MemoryCache.prototype.set = function (key, value, expireTime) {
  */
 MemoryCache.prototype.delete = function (key) {
     delete this._cache[key];
-    if (this._expires.hasOwnProperty(key)) {
+    if (key in this._expires) {
         clearTimeout(this._expires[key]);
         delete this._expires[key];
     }
@@ -54,13 +54,21 @@ MemoryCache.prototype.delete = function (key) {
  * Clears the whole cache storage.
  */
 MemoryCache.prototype.clear = function () {
-    this._cache = {};
+    this._cache = createMap();
     for (var key in this._expires) {
-        if (this._expires.hasOwnProperty(key)) {
-            clearTimeout(this._expires[key]);
-        }
+        clearTimeout(this._expires[key]);
     }
-    this._expires = {};
+    this._expires = createMap();
 };
+
+/**
+ * Creates a new object without a prototype. This object is useful for lookup without having to
+ * guard against prototypically inherited properties via hasOwnProperty.
+ *
+ * @returns {Object}
+ */
+function createMap() {
+    return Object.create(null);
+}
 
 module.exports = MemoryCache;

--- a/test/memory-cache.js
+++ b/test/memory-cache.js
@@ -89,6 +89,10 @@ describe('MemoryCache', function () {
 
             expect(cache.get('key')).to.not.exist;
         });
+
+        it('should not lookup to Object.prototype', function () {
+            expect(cache.get('hasOwnProperty')).to.not.exist;
+        });
     });
 
     describe('#delete', function () {
@@ -97,6 +101,12 @@ describe('MemoryCache', function () {
             cache.delete('key');
 
             expect(cache.get('key')).to.not.exist;
+        });
+
+        it('should work properly with "hasOwnProperty" key', function () {
+            cache.set('hasOwnProperty', 1, 1);
+            cache.delete('hasOwnProperty');
+            expect(cache.get('hasOwnProperty')).to.not.exist;
         });
     });
 
@@ -115,6 +125,12 @@ describe('MemoryCache', function () {
             clock.tick(100 * 1000);
 
             clock.restore();
+        });
+
+        it('should work properly with "hasOwnProperty" key', function () {
+            cache.set('hasOwnProperty', 1, 1);
+            cache.clear();
+            expect(cache.get('hasOwnProperty')).to.not.exist;
         });
     });
 });

--- a/test/memory-cache.js
+++ b/test/memory-cache.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var should = require('chai').should();
+var expect = require('chai').expect;
 var sinon = require('sinon');
 var MemoryCache = require('../lib/memory-cache');
 
@@ -18,25 +18,25 @@ describe('MemoryCache', function () {
             cache.set('key1', data1);
             cache.set('key2', data2);
 
-            cache.get('key1').should.equal(data1);
-            cache.get('key2').should.equal(data2);
+            expect(cache.get('key1')).to.equal(data1);
+            expect(cache.get('key2')).to.equal(data2);
         });
 
         it('should return undefiend for non-existed key', function () {
-            should.not.exist(cache.get('key'));
+            expect(cache.get('key')).to.not.exist;
         });
 
         it('should set expiration for data', function () {
             var clock = sinon.useFakeTimers();
 
             cache.set('key', 1, 100);
-            cache.get('key').should.equal(1);
+            expect(cache.get('key')).to.equal(1);
 
             clock.tick(50 * 1000);
-            cache.get('key').should.equal(1);
+            expect(cache.get('key')).to.equal(1);
 
             clock.tick(100 * 1000);
-            should.not.exist(cache.get('key'));
+            expect(cache.get('key')).to.not.exist;
 
             clock.restore();
         });
@@ -46,13 +46,13 @@ describe('MemoryCache', function () {
                 var clock = sinon.useFakeTimers();
 
                 cache.set('key', 'val', 0);
-                cache.get('key').should.equal('val');
+                expect(cache.get('key')).to.equal('val');
 
                 clock.tick(0);
-                cache.get('key').should.equal('val');
+                expect(cache.get('key')).to.equal('val');
 
                 clock.tick(100 * 1000);
-                cache.get('key').should.equal('val');
+                expect(cache.get('key')).to.equal('val');
             });
         });
 
@@ -63,10 +63,10 @@ describe('MemoryCache', function () {
             cache.set('key', 2, 100);
 
             clock.tick(50 * 1000);
-            cache.get('key').should.equal(2);
+            expect(cache.get('key')).to.equal(2);
 
             clock.tick(100 * 1000);
-            should.not.exist(cache.get('key'));
+            expect(cache.get('key')).to.not.exist;
 
             clock.restore();
         });
@@ -78,7 +78,7 @@ describe('MemoryCache', function () {
             cache.set('key', 2);
 
             clock.tick(1000);
-            cache.get('key').should.equal(2);
+            expect(cache.get('key')).to.equal(2);
 
             clock.restore();
         });
@@ -87,7 +87,7 @@ describe('MemoryCache', function () {
             var otherCache = new MemoryCache();
             otherCache.set('key', 1);
 
-            should.not.exist(cache.get('key'));
+            expect(cache.get('key')).to.not.exist;
         });
     });
 
@@ -96,20 +96,20 @@ describe('MemoryCache', function () {
             cache.set('key', 1);
             cache.delete('key');
 
-            should.not.exist(cache.get('key'));
+            expect(cache.get('key')).to.not.exist;
         });
     });
 
     describe('#clear', function () {
-        it('should clear data', function () {
+        it('should clear all data', function () {
             var clock = sinon.useFakeTimers();
 
             cache.set('key1', 1);
             cache.set('key2', 2, 100);
 
             cache.clear();
-            should.not.exist(cache.get('key1'));
-            should.not.exist(cache.get('key2'));
+            expect(cache.get('key1')).to.not.exist;
+            expect(cache.get('key2')).to.not.exist;
 
             // Should not throw error after expiration time.
             clock.tick(100 * 1000);

--- a/test/memory-cache.js
+++ b/test/memory-cache.js
@@ -11,7 +11,7 @@ describe('MemoryCache', function () {
         cache = new MemoryCache();
     });
 
-    describe('set()', function () {
+    describe('#set/#get', function () {
         it('should set data by keys', function () {
             var data1 = {};
             var data2 = {};
@@ -82,9 +82,16 @@ describe('MemoryCache', function () {
 
             clock.restore();
         });
+
+        it('should not see data from the other cache', function () {
+            var otherCache = new MemoryCache();
+            otherCache.set('key', 1);
+
+            should.not.exist(cache.get('key'));
+        });
     });
 
-    describe('delete()', function () {
+    describe('#delete', function () {
         it('should delete data by key', function () {
             cache.set('key', 1);
             cache.delete('key');
@@ -93,7 +100,7 @@ describe('MemoryCache', function () {
         });
     });
 
-    describe('clear()', function () {
+    describe('#clear', function () {
         it('should clear data', function () {
             var clock = sinon.useFakeTimers();
 
@@ -109,12 +116,5 @@ describe('MemoryCache', function () {
 
             clock.restore();
         });
-    });
-
-    it('should not see data from the other cache', function () {
-        var otherCache = new MemoryCache();
-        otherCache.set('key', 1);
-
-        should.not.exist(cache.get('key'));
     });
 });


### PR DESCRIPTION
- Empty cache returns value of properties from `Object.prototype`:

``` js
var cache = new MemoryCache();
cache.get('hasOwnProperty'); // returns function, expected undefined
```
- Cache uses value of `hasOwnProperty` key:

``` js
var cache = new MemoryCache();
cache.set('hasOwnProperty', 1, 1);
cache.delete('hasOwnProperty'); // throws error 'hasOwnProperty is not a function'
```
